### PR TITLE
Add explanation about how to deal with size_range

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,23 @@ class User < ApplicationRecord
   # validates :photos, presence: true, blob: { content_type: %r{^image/}, size_range: 1..5.megabytes }
 end
 ```
-
 Note: For `has_many_attached`, size is validated on each file individually. In the code above, `:photos` validation allows any number of photos to be upload, each one being 5 MB or less in size.
+
+When declaring `size_range`, you might want to assign the values of the ranges into variables for passing rubocop linters, to create [an unambiguous range](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/lint/ambiguous_range.rb).
+
+```ruby
+class User < ApplicationRecord
+  has_many_attached :photos
+  
+  @min_size = 1.megabytes
+  @max_size = 5.megabytes
+  
+  validates :photos, presence: true, blob: {
+    content_type: ['image/png', 'image/jpg', 'image/jpeg'],
+    size_range: @min_size..@max_size
+  }
+end
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ end
 ```
 Note: For `has_many_attached`, size is validated on each file individually. In the code above, `:photos` validation allows any number of photos to be upload, each one being 5 MB or less in size.
 
-When declaring `size_range`, you might want to assign the values of the ranges into variables for passing rubocop linters, to create [an unambiguous range](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/lint/ambiguous_range.rb).
+When declaring `size_range`, you might want to assign the values of the ranges into variables for passing rubocop linters, to create a [Single Source of Truth](https://www.talend.com/resources/single-source-truth/) and avoid [an unambiguous range](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/lint/ambiguous_range.rb).
 
 ```ruby
 class User < ApplicationRecord


### PR DESCRIPTION
# Add explanation about how to deal with size_range

## Problem
The proposed range by the author was not able to pass through some rubocop linters that I use, by accusing the range to be [an ambiguous range](https://github.com/rubocop/rubocop/blob/master/lib/rubocop/cop/lint/ambiguous_range.rb).
It is also worth mentioning that if multiple, different files were to be stored, we would not have a [Single Source of Truth](https://www.talend.com/resources/single-source-truth/) for the `size_range`, which could lead to potential misbehavior on the application.

## Proposed solution
Suggest to the User that by changing the size_range to be composed of a range of two variables, we can create a Single Source of Truth that is also Unambiguous for the Rubocop:

```ruby
class User < ApplicationRecord
  has_many_attached :photos
  
  @min_size = 1.megabytes
  @max_size = 5.megabytes
  
  validates :photos, presence: true, blob: {
    content_type: ['image/png', 'image/jpg', 'image/jpeg'],
    size_range: @min_size..@max_size
  }
end
```