### PR TITLE
Add Ruby 3.1 and Rails 7 to the CI matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -22,8 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0]
-        gemfile: [rails60, rails61]
+        ruby: [2.7, '3.0', 3.1]
+        gemfile: [rails60, rails61, rails70]
+        exclude:
+          - ruby: 3.1
+            gemfile: rails60
     steps:
       - name: Install packages
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 # rspec failure tracking
 .rspec_status
 /Gemfile.lock
+gemfiles/*.lock
 *.sqlite
 Gemfile.local

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem 'rails', '~> 7.0.0'
+gem 'sqlite3'
+
+gemspec path: '../'

--- a/spec/support/blob_helper.rb
+++ b/spec/support/blob_helper.rb
@@ -1,6 +1,10 @@
 module BlobHelper
   def create_file_blob(filename:, content_type: "image/jpeg", metadata: nil)
-    ActiveStorage::Blob.create_after_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata
+    if Rails::VERSION::MAJOR < 6 || (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR == 0) 
+      ActiveStorage::Blob.create_after_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata
+    else
+      ActiveStorage::Blob.create_and_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata
+    end
   end
 
   private


### PR DESCRIPTION
Adds Ruby 3.1 and Rails 7 to the CI matrix.  In addition to the minimal configuration change and new Gemfile, this PR:

1. Quotes the `3.0` in the CI configuration.  An unquoted `3.0` is truncated to `3`, and will load the latest Ruby 3 version - at this time `3.1.1`
2. Adjusts `BlobHelper` for the deprecation of the `create_after_upload!` method in Rails 6.1 and its removal in Rails 7.0.
3. Adds `gemfiles/*.lock` to the `.gitignore`