### PR TITLE
fea: Add Content type and size range like lambdas

### DIFF
--- a/lib/activestorage/validator/blob.rb
+++ b/lib/activestorage/validator/blob.rb
@@ -6,14 +6,15 @@ module ActiveRecord
 
         Array(values).each do |value|
           if options[:size_range].present?
-            if options[:size_range].min > value.blob.byte_size
-              record.errors.add(attribute, :min_size_error, min_size: ActiveSupport::NumberHelper.number_to_human_size(options[:size_range].min))
-            elsif options[:size_range].max < value.blob.byte_size
-              record.errors.add(attribute, :max_size_error, max_size: ActiveSupport::NumberHelper.number_to_human_size(options[:size_range].max))
+            if options[:size_range].is_a? Proc
+              range = record.instance_exec(&options[:size_range])
+              size_range_error(record, attribute, range, value)
+            else
+              size_range_error(record, attribute, options[:size_range], value)
             end
           end
 
-          unless valid_content_type?(value.blob)
+          unless valid_content_type?(record, value.blob)
             record.errors.add(attribute, :content_type)
           end
         end
@@ -21,22 +22,41 @@ module ActiveRecord
 
       private
 
-        def valid_content_type?(blob)
-          return true if options[:content_type].nil?
-
-          case options[:content_type]
-          when Regexp
-            options[:content_type].match?(blob.content_type)
-          when Array
-            options[:content_type].include?(blob.content_type)
-          when :web_image
-            ActiveStorage.web_image_content_types.include?(blob.content_type)
-          when Symbol
-            blob.public_send("#{options[:content_type]}?")
-          else
-            options[:content_type] == blob.content_type
-          end
+      def size_range_error(record, attribute, range, value)
+        if range.min > value.blob.byte_size
+          record.errors.add(
+            attribute,
+            :min_size_error,
+            min_size: ActiveSupport::NumberHelper.number_to_human_size(range.min)
+          )
+        elsif range.max < value.blob.byte_size
+          record.errors.add(
+            attribute,
+            :max_size_error,
+            max_size: ActiveSupport::NumberHelper.number_to_human_size(range.max)
+          )
         end
+      end
+
+      def valid_content_type?(record, blob)
+        return true if options[:content_type].nil?
+
+        case options[:content_type]
+        when Regexp
+          options[:content_type].match?(blob.content_type)
+        when Array
+          options[:content_type].include?(blob.content_type)
+        when :web_image
+          ActiveStorage.web_image_content_types.include?(blob.content_type)
+        when Symbol
+          blob.public_send("#{options[:content_type]}?")
+        when Proc
+          content_types = record.instance_exec(&options[:content_type])
+          content_types.include?(blob.content_type)
+        else
+          options[:content_type] == blob.content_type
+        end
+      end
     end
   end
 end

--- a/spec/activestorage/validator/blob_spec.rb
+++ b/spec/activestorage/validator/blob_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe ActiveRecord::Validations::BlobValidator do
         expect(user.errors.messages[:file][0]).to eq 'File size should be less than 1 MB'
       end
     end
+
+    context 'when size_range is a proc' do
+      let(:size_range_proc) { -> { 1..1.megabyte } }
+
+      before do
+        User.validates :file, blob: { size_range: size_range_proc }
+        User.validates :files, blob: { size_range: size_range_proc }
+      end
+
+      it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+    end
   end
 
   describe 'with content_type option' do
@@ -104,6 +115,18 @@ RSpec.describe ActiveRecord::Validations::BlobValidator do
 
       it { expect(User.new(files: [create_file_blob(filename: '600KB.jpg')]).valid?).to eq true }
       it { expect(User.new(files: [create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')]).valid?).to eq false }
+    end
+
+    context 'Proc' do
+      let(:content_type_proc) { -> { Array.wrap('image/jpeg') } }
+
+      before do
+        User.validates :file, blob: { content_type: content_type_proc }
+        User.validates :files, blob: { content_type: content_type_proc }
+      end
+
+      it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+      it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq false }
     end
   end
 end


### PR DESCRIPTION
Motivation / Background:
Within my React/Ruby application, there's a need for dynamic functionality that allows for the adjustment of content type and size ranges based on a configuration model. This model serves as a shared point of reference between the frontend and backend, ensuring consistency in validation criteria across both ends.

This Pull Request addresses this need by introducing the capability to utilize lambdas for defining content types and size ranges, thereby enhancing the flexibility and adaptability of these validations.

Detail:
This Pull Request enables the utilization of lambdas for specifying content type and size range validations, thus providing greater versatility to these checks. Here's an example of how it works:

```ruby
belongs_to :config
validates :file, blob: {
	content_type: -> { dynamic_content_type },
	size_range: -> { dynamic_size_range }
}

def dynamic_content_type
	config.content_types
end

def dynamic_size_range
	config.size_ranges
end
```
