### PR TITLE
feat: add agent skill files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ en:
 - Some features may not work depending on your ActiveStorage or Rails version.
 - Validation error messages are I18n compatible and support interpolation keys as described above.
 
+## Agent skill
+
+This repo ships an [agent skill](skills/activestorage-validator/) (`SKILL.md`,
+plus a Japanese `SKILL-ja.md`) that teaches coding agents when and how to apply
+`activestorage-validator`. Install it into your project with the GitHub CLI:
+
+```sh
+gh skill install aki77/activestorage-validator
+```
+
+> `gh skill` is currently a GitHub CLI preview feature.
+
+Alternatively, if your project already pulls `activestorage-validator` in via
+Bundler, the [bundler-skills](https://github.com/aki77/bundler-skills) plugin
+auto-syncs this skill on `bundle install` — keeping the skill version locked to
+the gem version.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub via [issues](https://github.com/aki77/activestorage-validator/issues) or [pull requests](https://github.com/aki77/activestorage-validator/pulls).

--- a/activestorage-validator.gemspec
+++ b/activestorage-validator.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) || f.match(%r{^skills/.*-ja\.md$}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/lib/activestorage/validator/version.rb
+++ b/lib/activestorage/validator/version.rb
@@ -1,5 +1,5 @@
 module ActiveStorage
   module Validator
-    VERSION = '0.6.0'
+    VERSION = '0.7.0'
   end
 end

--- a/skills/activestorage-validator/SKILL-ja.md
+++ b/skills/activestorage-validator/SKILL-ja.md
@@ -1,0 +1,123 @@
+---
+name: activestorage-validator
+description: "activestorage-validator gem の `blob` バリデータで ActiveStorage 添付ファイル（content type・サイズ・拡張子）を検証する。has_one_attached / has_many_attached 属性にバリデーションを追加するときに使う。"
+---
+
+# activestorage-validator
+
+ActiveStorage 添付ファイル用の `blob` バリデータを追加する Rails gem。`has_one_attached` /
+`has_many_attached` の両方に対して、content type・ファイルサイズ・拡張子を検証する。
+
+## まず適用可否を判断する
+
+この gem は **ActiveStorage の添付ファイル検証専用**。添付以外の通常属性は標準の Rails
+バリデータ（`presence` / `length` / `numericality` など）を使うこと。
+
+| 検証対象 | 使うもの |
+| --- | --- |
+| ActiveStorage 添付（content type / サイズ / 拡張子） | **`blob:` バリデータ（この gem）** |
+| 通常の文字列/数値/真偽値カラム | 標準の Rails バリデータ |
+| 添付そのものの存在 | `presence: true`（`blob:` と併用可） |
+
+特別な読み取りパスは不要。`validates ..., blob: { ... }` を宣言すれば、他の Rails
+バリデーションと同様に `save` / `valid?` 時に添付が検証される。
+
+## 使い方
+
+モデルに `blob:` バリデータを宣言する。
+
+```ruby
+class User < ApplicationRecord
+  has_one_attached :avatar
+  has_many_attached :photos
+
+  # web 画像（PNG, JPEG, GIF, WebP）のみ許可
+  validates :avatar, presence: true, blob: { content_type: :web_image }
+
+  # JPEG/PNG のみ・1 ファイル 5MB まで
+  validates :photos, presence: true, blob: {
+    content_type: ["image/png", "image/jpg", "image/jpeg"],
+    size_range: 1..(5.megabytes)
+  }
+
+  # Regexp content_type ＋ 拡張子必須（AND 条件）
+  validates :audio, blob: { content_type: "audio/mpeg", extension: %w[mp3] }
+end
+```
+
+> `has_many_attached` では、すべてのオプション（`size_range` を含む）が **各ファイルごとに**
+> 適用される。
+
+## オプション（すべて任意・自由に組み合わせ可）
+
+| オプション | 受け付ける型 | 備考 |
+| --- | --- | --- |
+| `content_type` | Symbol / Array / Regexp / String | 許可する MIME タイプ。マッチ方法は下記。 |
+| `size_range` | Range | 許可するバイトサイズ。例 `1..(5.megabytes)`。 |
+| `extension` | String / Array | 許可するファイル拡張子。 |
+
+### `content_type` のマッチ
+
+- **`:web_image`** — `ActiveStorage.web_image_content_types`（PNG, JPEG, GIF, WebP）に
+  特別対応。ブラウザで安全に表示できる画像のみを許可したいときは `:image` でなくこちらを使う。
+- **その他の Symbol**（`:image` / `:audio` / `:video` / `:text`）— ActiveStorage 組み込み述語
+  `blob.image?` / `blob.audio?` 等を呼ぶ。
+- **Array** — `["image/png", "image/jpeg"]`: blob の content type がリストに含まれるか。
+- **Regexp** — `%r{^image/}`: blob の content type にマッチさせる。
+- **String** — `"application/pdf"`: 完全一致。
+
+### `extension` のマッチ
+
+- String（`"mp3"`）または Array（`%w[mp3 m4a]`）。
+- 先頭ドットは任意（`"mp3"` と `".mp3"` は同じ）。
+- 大文字小文字を区別しない（`PHOTO.JPG` は `extension: "jpg"` にマッチ）。
+- `extension` 指定時、**拡張子のないファイルは常に reject** される。
+- `content_type` と併用すると両方を満たす必要がある（AND）。例えば
+  `{ content_type: "audio/mpeg", extension: %w[mp3] }` は、MIME タイプが `audio/mpeg` でも
+  `.wav` ファイルを reject する。
+
+## I18n エラーメッセージ
+
+エラーは I18n 対応。エラータイプと補間キー:
+
+| エラータイプ | 補間キー | 発生条件 |
+| --- | --- | --- |
+| `content_type` | `filename` | content type が許可外 |
+| `min_size_error` | `filename`, `min_size` | `size_range.min` より小さい |
+| `max_size_error` | `filename`, `max_size` | `size_range.max` より大きい |
+| `extension` | `filename`, `extension` | 拡張子が許可外（または無し） |
+
+`min_size` / `max_size` は humanize される（`ActiveSupport::NumberHelper.number_to_human_size`）。
+`extension` は許可拡張子を `, ` で連結した文字列。
+
+```yaml
+# config/locales/ja.yml
+ja:
+  errors:
+    messages:
+      content_type: "%{filename}のコンテンツタイプが正しくありません"
+      min_size_error: "%{filename}が小さすぎます（最小%{min_size}）"
+      max_size_error: "%{filename}が大きすぎます（最大%{max_size}）"
+      extension: "%{filename}の拡張子が正しくありません（許可: %{extension}）"
+```
+
+この gem は 7 言語のデフォルトメッセージを同梱している: `en`, `ja`, `de`, `es`, `fr`,
+`pl`, `pt-br`。上記キーを使ってアプリ側の locale ファイルで上書きできる。
+
+## 実装由来の挙動
+
+- **未添付の値はスキップ。** 添付されていない場合は早期 return するため、`blob:` は存在を
+  強制しない。必須なら `presence: true` を別途付ける。
+- **サイズ境界は両端を含む。** `size_range.min <= byte_size <= size_range.max` で有効。
+  min 未満 → `min_size_error`、max 超過 → `max_size_error`。
+- **拡張子の正規化** は `downcase` ＋ 先頭ドット 1 個の除去。正規化後が空（拡張子なし）なら fail。
+- 各オプションは独立。不要なものは省略でき、指定したものだけが実行される。
+
+## 落とし穴
+
+- `extension:` を指定すると、**拡張子のないファイル**は content type が許可されていても reject
+  される。拡張子なしアップロードを受け付けたい場合は `extension:` を設定しないこと。
+- `has_many_attached` では `size_range` は合計でなく **ファイルごと**に適用される。
+- `blob:` 単体では添付を必須にしない。必須にするなら `presence: true` を併用する。
+- 特別な読み取り/プリロードのパスは無い。これは普通の `EachValidator` で、標準の `valid?` /
+  `save` 時に実行される。

--- a/skills/activestorage-validator/SKILL.md
+++ b/skills/activestorage-validator/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: activestorage-validator
+description: "Validate ActiveStorage attachments (content type, file size, file extension) with the activestorage-validator gem's `blob` validator. Use when adding validations to has_one_attached / has_many_attached attributes."
+---
+
+# activestorage-validator
+
+A Rails gem that adds a `blob` validator for ActiveStorage attachments. It
+validates content type, file size, and file extension on both
+`has_one_attached` and `has_many_attached` attributes.
+
+## First: determine applicability
+
+Use this gem **only** for validating ActiveStorage attachments. For ordinary
+(non-attachment) attributes, use the standard Rails validators (`presence`,
+`length`, `numericality`, etc.).
+
+| What you validate | Tool |
+| --- | --- |
+| ActiveStorage attachment (content type / size / extension) | **`blob:` validator (this gem)** |
+| Plain string/number/boolean columns | Standard Rails validators |
+| Presence of the attachment itself | `presence: true` (works alongside `blob:`) |
+
+There is no special read path — declare `validates ..., blob: { ... }` and the
+attachment is validated like any other Rails validation on `save`/`valid?`.
+
+## Usage
+
+Declare validations on the model with the `blob:` validator.
+
+```ruby
+class User < ApplicationRecord
+  has_one_attached :avatar
+  has_many_attached :photos
+
+  # Allow only web image files (PNG, JPEG, GIF, WebP)
+  validates :avatar, presence: true, blob: { content_type: :web_image }
+
+  # Allow only JPEG/PNG, up to 5MB per file
+  validates :photos, presence: true, blob: {
+    content_type: ["image/png", "image/jpg", "image/jpeg"],
+    size_range: 1..(5.megabytes)
+  }
+
+  # Regexp content_type + required extension (AND condition)
+  validates :audio, blob: { content_type: "audio/mpeg", extension: %w[mp3] }
+end
+```
+
+> For `has_many_attached`, every option (including `size_range`) is applied to
+> **each file individually**.
+
+## Options (all optional, combine freely)
+
+| Option | Accepts | Notes |
+| --- | --- | --- |
+| `content_type` | Symbol / Array / Regexp / String | Allowed MIME type(s). See matching below. |
+| `size_range` | Range | Allowed byte size, e.g. `1..(5.megabytes)`. |
+| `extension` | String / Array | Allowed filename extension(s). |
+
+### `content_type` matching
+
+- **`:web_image`** — special-cased to `ActiveStorage.web_image_content_types`
+  (PNG, JPEG, GIF, WebP). Use this instead of `:image` when you want only
+  browser-safe images.
+- **Other Symbol** (`:image`, `:audio`, `:video`, `:text`) — calls the
+  ActiveStorage built-in predicate `blob.image?` / `blob.audio?` / etc.
+- **Array** — `["image/png", "image/jpeg"]`: exact membership of the blob's
+  content type in the list.
+- **Regexp** — `%r{^image/}`: matched against the blob's content type.
+- **String** — `"application/pdf"`: exact equality.
+
+### `extension` matching
+
+- Accepts a String (`"mp3"`) or Array (`%w[mp3 m4a]`).
+- Leading dot is optional (`"mp3"` == `".mp3"`).
+- Case-insensitive (`PHOTO.JPG` matches `extension: "jpg"`).
+- **A file with no extension is always rejected** when `extension` is set.
+- When combined with `content_type`, both must pass (AND). E.g.
+  `{ content_type: "audio/mpeg", extension: %w[mp3] }` rejects a `.wav` file
+  even if its MIME type happens to be `audio/mpeg`.
+
+## I18n error messages
+
+Errors are I18n-compatible. Error types and their interpolation keys:
+
+| Error type | Interpolation keys | When |
+| --- | --- | --- |
+| `content_type` | `filename` | content type not allowed |
+| `min_size_error` | `filename`, `min_size` | smaller than `size_range.min` |
+| `max_size_error` | `filename`, `max_size` | larger than `size_range.max` |
+| `extension` | `filename`, `extension` | extension not allowed (or missing) |
+
+`min_size` / `max_size` are humanized (`ActiveSupport::NumberHelper.number_to_human_size`).
+`extension` is the allowed list joined by `, `.
+
+```yaml
+# config/locales/en.yml
+en:
+  errors:
+    messages:
+      content_type: "%{filename} has an invalid content type"
+      min_size_error: "%{filename} is too small (minimum is %{min_size})"
+      max_size_error: "%{filename} is too large (maximum is %{max_size})"
+      extension: "%{filename} has an invalid file extension (allowed: %{extension})"
+```
+
+The gem ships default messages for 7 locales: `en`, `ja`, `de`, `es`, `fr`,
+`pl`, `pt-br`. Override them in your app's locale files using the keys above.
+
+## Behavior details
+
+- **Unattached values are skipped.** Validation returns early unless the
+  attachment is attached, so `blob:` does not enforce presence — add
+  `presence: true` separately if the attachment is required.
+- **Size boundaries are inclusive.** A blob is valid when
+  `size_range.min <= byte_size <= size_range.max`. Below min → `min_size_error`;
+  above max → `max_size_error`.
+- **Extension normalization** is `downcase` + strip a single leading dot; an
+  empty resulting extension (no extension on the file) fails.
+- Options are independent — omit any you don't need; only the present ones run.
+
+## Pitfalls
+
+- A file **without an extension** is rejected whenever `extension:` is set —
+  even if its content type is allowed. Don't set `extension:` if you accept
+  extension-less uploads.
+- For `has_many_attached`, `size_range` applies **per file**, not to the total.
+- `blob:` alone does **not** require an attachment; pair it with `presence: true`
+  when the upload is mandatory.
+- No special read/preload path exists — this is a plain `EachValidator`; it runs
+  on standard `valid?` / `save`.


### PR DESCRIPTION
- Add `skills/activestorage-validator/SKILL.md` and `SKILL-ja.md` as agent skill files for coding agents
- Exclude `SKILL-ja.md` from the gem package via gemspec (SKILL.md is still shipped)
- Add "Agent skill" section to README and bump version to 0.7.0