### PR TITLE
chore: drop EOL Ruby/Rails versions, add Ruby 4.0 and Rails 8.1

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -23,21 +23,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { ruby: "3.0", gemfile: "rails61" }
-          - { ruby: "3.1", gemfile: "rails61" }
-          - { ruby: "3.2", gemfile: "rails61" }
-          - { ruby: "3.0", gemfile: "rails70" }
-          - { ruby: "3.1", gemfile: "rails70" }
-          - { ruby: "3.2", gemfile: "rails70" }
-          - { ruby: "3.0", gemfile: "rails71" }
-          - { ruby: "3.1", gemfile: "rails71" }
-          - { ruby: "3.2", gemfile: "rails71" }
-          - { ruby: "3.2", gemfile: "rails72" }
           - { ruby: "3.3", gemfile: "rails72" }
           - { ruby: "3.4", gemfile: "rails72" }
-          - { ruby: "3.2", gemfile: "rails80" }
+          - { ruby: "4.0", gemfile: "rails72" }
           - { ruby: "3.3", gemfile: "rails80" }
           - { ruby: "3.4", gemfile: "rails80" }
+          - { ruby: "4.0", gemfile: "rails80" }
+          - { ruby: "3.3", gemfile: "rails81" }
+          - { ruby: "3.4", gemfile: "rails81" }
+          - { ruby: "4.0", gemfile: "rails81" }
     steps:
       - name: Install packages
         run: |

--- a/activestorage-validator.gemspec
+++ b/activestorage-validator.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.3.0'
 
-  spec.add_dependency "rails", ">= 6.1.0"
+  spec.add_dependency "rails", ">= 7.2.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/activestorage-validator.gemspec
+++ b/activestorage-validator.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.3.0'
 
   spec.add_dependency "rails", ">= 7.2.0"
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "combustion"

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -1,7 +1,0 @@
-source "http://rubygems.org"
-
-gem 'rails', '6.1.4'
-gem 'sqlite3', '~> 1.4'
-gem 'concurrent-ruby', '< 1.3.5'
-
-gemspec path: '../'

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -1,7 +1,0 @@
-source "http://rubygems.org"
-
-gem 'rails', '~> 7.0.0'
-gem 'sqlite3', '~> 1.4'
-gem 'concurrent-ruby', '< 1.3.5'
-
-gemspec path: '../'

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -1,6 +1,0 @@
-source "http://rubygems.org"
-
-gem 'rails', '~> 7.1.0'
-gem 'sqlite3'
-
-gemspec path: '../'

--- a/gemfiles/rails72.gemfile
+++ b/gemfiles/rails72.gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem 'rails', '~> 7.2.0'
 gem 'sqlite3'

--- a/gemfiles/rails80.gemfile
+++ b/gemfiles/rails80.gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem 'rails', '~> 8.0.0'
 gem 'sqlite3'

--- a/gemfiles/rails81.gemfile
+++ b/gemfiles/rails81.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem 'rails', '~> 8.1.0'
+gem 'sqlite3'
+
+gemspec path: '../'


### PR DESCRIPTION
- Remove Ruby 3.0/3.1/3.2 (EOL) and Rails 6.1/7.0/7.1 (EOL) from CI matrix; add Ruby 4.0 and Rails 8.1
- Add `gemfiles/rails81.gemfile`; bump `required_ruby_version` to `>= 3.3.0` and rails dependency to `>= 7.2.0`
- Fix RubyGems source URL from `http://` to `https://` in all gemfiles