### PR TITLE
feat: support Proc/lambda for content_type, size_range and extension options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 gemfiles/*.lock
 *.sqlite
 Gemfile.local
+CLAUDE.local.md

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ end
 
 | Option        | Description                                                                                 |
 |--------------|---------------------------------------------------------------------------------------------|
-| content_type | Allowed MIME types. Accepts a symbol (`:web_image`, `:image`, `:audio`, `:video`, `:text`), an array of MIME types, a regular expression, or a string (single MIME type). |
-| size_range   | Allowed file size range (e.g. `1..5.megabytes`)                                             |
-| extension    | Allowed file extensions. Accepts a String or an Array of Strings. Case-insensitive, leading dot optional. Files without an extension are rejected. |
+| content_type | Allowed MIME types. Accepts a symbol (`:web_image`, `:image`, `:audio`, `:video`, `:text`), an array of MIME types, a regular expression, or a string (single MIME type). Or a Proc/lambda returning one of the above. |
+| size_range   | Allowed file size range (e.g. `1..5.megabytes`). Or a Proc/lambda returning a Range.        |
+| extension    | Allowed file extensions. Accepts a String or an Array of Strings. Case-insensitive, leading dot optional. Files without an extension are rejected. Or a Proc/lambda returning one of the above. |
 
 ### content_type Examples
 
@@ -81,6 +81,29 @@ end
   - `blob: { content_type: "audio/mpeg", extension: %w[mp3] }` ... Reject both `my_podcast` (no extension) and `my_podcast.wav` (wrong extension), even when their MIME types match.
 
 The leading dot is optional (`"mp3"` and `".mp3"` behave the same), and matching is case-insensitive (`PHOTO.JPG` matches `extension: "jpg"`).
+
+## Dynamic Options (Proc/lambda)
+
+Every option (`content_type`, `size_range`, `extension`) also accepts a Proc/lambda,
+so you can decide the allowed values per record at validation time:
+
+```ruby
+validates :avatar, blob: {
+  content_type: ->(record) { record.premium? ? %w[image/png image/jpeg] : :web_image },
+  size_range:   ->(record) { 1..(record.premium? ? 20.megabytes : 5.megabytes) }
+}
+```
+
+The Proc is resolved with the same arity convention as Rails' built-in validators
+(the same rule used by `if:` / `unless:`):
+
+- **No argument** (`-> { ... }`) — called as-is.
+- **One argument** (`->(record) { ... }`) — the record is passed in.
+
+The Proc must return a value of one of the types the option already accepts
+(a Symbol/Array/Regexp/String for `content_type`, a Range for `size_range`, a
+String/Array for `extension`). For `has_many_attached`, the Proc is evaluated
+once per record (not per attached file).
 
 ## I18n Error Message Options
 

--- a/lib/activestorage/validator/blob.rb
+++ b/lib/activestorage/validator/blob.rb
@@ -4,25 +4,23 @@ module ActiveRecord
       def validate_each(record, attribute, values) # rubocop:disable Metrics/AbcSize
         return unless values.attached?
 
-        Array(values).each do |value|
-          if options[:size_range].present?
-            if options[:size_range].min > value.blob.byte_size
-              record.errors.add(attribute, :min_size_error, min_size: ActiveSupport::NumberHelper.number_to_human_size(options[:size_range].min), filename: value.blob.filename.to_s)
-            elsif options[:size_range].max < value.blob.byte_size
-              record.errors.add(attribute, :max_size_error, max_size: ActiveSupport::NumberHelper.number_to_human_size(options[:size_range].max), filename: value.blob.filename.to_s)
-            end
-          end
+        size_range   = resolve_option(record, options[:size_range])
+        content_type = resolve_option(record, options[:content_type])
+        extension    = resolve_option(record, options[:extension])
 
-          unless valid_content_type?(value.blob)
+        Array(values).each do |value|
+          validate_size(record, attribute, value, size_range) if size_range.present?
+
+          unless valid_content_type?(value.blob, content_type)
             record.errors.add(attribute, :content_type, filename: value.blob.filename.to_s)
           end
 
-          unless valid_extension?(value.blob)
+          unless valid_extension?(value.blob, extension)
             record.errors.add(
               attribute,
               :extension,
               filename: value.blob.filename.to_s,
-              extension: Array(options[:extension]).map { |e| normalize_extension(e) }.join(', ')
+              extension: Array(extension).map { |e| normalize_extension(e) }.join(', ')
             )
           end
         end
@@ -30,27 +28,46 @@ module ActiveRecord
 
       private
 
-        def valid_content_type?(blob)
-          return true if options[:content_type].nil?
+        # Resolve only when the value is a Proc, using the same arity convention
+        # as Rails' built-in validators: arity 0 calls the proc as-is, otherwise
+        # the record is passed in. Anything else (Symbol/String/Array/Regexp/
+        # Range/nil) is returned untouched, preserving backward compatibility.
+        def resolve_option(record, value)
+          return value unless value.is_a?(Proc)
 
-          case options[:content_type]
-          when Regexp
-            options[:content_type].match?(blob.content_type)
-          when Array
-            options[:content_type].include?(blob.content_type)
-          when :web_image
-            ActiveStorage.web_image_content_types.include?(blob.content_type)
-          when Symbol
-            blob.public_send("#{options[:content_type]}?")
-          else
-            options[:content_type] == blob.content_type
+          value.arity.zero? ? value.call : value.call(record)
+        end
+
+        def validate_size(record, attribute, value, size_range)
+          byte_size = value.blob.byte_size
+          if size_range.min > byte_size
+            record.errors.add(attribute, :min_size_error, min_size: ActiveSupport::NumberHelper.number_to_human_size(size_range.min), filename: value.blob.filename.to_s)
+          elsif size_range.max < byte_size
+            record.errors.add(attribute, :max_size_error, max_size: ActiveSupport::NumberHelper.number_to_human_size(size_range.max), filename: value.blob.filename.to_s)
           end
         end
 
-        def valid_extension?(blob)
-          return true if options[:extension].nil?
+        def valid_content_type?(blob, content_type)
+          return true if content_type.nil?
 
-          allowed = Array(options[:extension]).map { |e| normalize_extension(e) }
+          case content_type
+          when Regexp
+            content_type.match?(blob.content_type)
+          when Array
+            content_type.include?(blob.content_type)
+          when :web_image
+            ActiveStorage.web_image_content_types.include?(blob.content_type)
+          when Symbol
+            blob.public_send("#{content_type}?")
+          else
+            content_type == blob.content_type
+          end
+        end
+
+        def valid_extension?(blob, extension)
+          return true if extension.nil?
+
+          allowed = Array(extension).map { |e| normalize_extension(e) }
           actual = normalize_extension(blob.filename.extension)
           return false if actual.empty?
 

--- a/skills/activestorage-validator/SKILL-ja.md
+++ b/skills/activestorage-validator/SKILL-ja.md
@@ -52,9 +52,15 @@ end
 
 | オプション | 受け付ける型 | 備考 |
 | --- | --- | --- |
-| `content_type` | Symbol / Array / Regexp / String | 許可する MIME タイプ。マッチ方法は下記。 |
-| `size_range` | Range | 許可するバイトサイズ。例 `1..(5.megabytes)`。 |
-| `extension` | String / Array | 許可するファイル拡張子。 |
+| `content_type` | Symbol / Array / Regexp / String / Proc | 許可する MIME タイプ。マッチ方法は下記。 |
+| `size_range` | Range / Proc | 許可するバイトサイズ。例 `1..(5.megabytes)`。 |
+| `extension` | String / Array / Proc | 許可するファイル拡張子。 |
+
+いずれのオプションも、記載の型を返す **Proc/lambda** を受け付ける。解決は Rails 標準
+バリデータ（`if:` / `unless:`）と同じ arity 規約: `-> { ... }` はそのまま呼び、
+`->(record) { ... }` には record が渡される。`has_many_attached` では Proc は record
+ごとに1回評価される。例:
+`content_type: ->(record) { record.premium? ? %w[image/png] : :web_image }`。
 
 ### `content_type` のマッチ
 

--- a/skills/activestorage-validator/SKILL.md
+++ b/skills/activestorage-validator/SKILL.md
@@ -54,9 +54,15 @@ end
 
 | Option | Accepts | Notes |
 | --- | --- | --- |
-| `content_type` | Symbol / Array / Regexp / String | Allowed MIME type(s). See matching below. |
-| `size_range` | Range | Allowed byte size, e.g. `1..(5.megabytes)`. |
-| `extension` | String / Array | Allowed filename extension(s). |
+| `content_type` | Symbol / Array / Regexp / String / Proc | Allowed MIME type(s). See matching below. |
+| `size_range` | Range / Proc | Allowed byte size, e.g. `1..(5.megabytes)`. |
+| `extension` | String / Array / Proc | Allowed filename extension(s). |
+
+Any option also accepts a **Proc/lambda** returning a value of the listed type,
+resolved with the same arity convention as Rails' built-in validators (`if:` /
+`unless:`): `-> { ... }` is called as-is, `->(record) { ... }` receives the
+record. For `has_many_attached` the Proc is evaluated once per record. Example:
+`content_type: ->(record) { record.premium? ? %w[image/png] : :web_image }`.
 
 ### `content_type` matching
 

--- a/spec/activestorage/validator/blob_spec.rb
+++ b/spec/activestorage/validator/blob_spec.rb
@@ -171,6 +171,198 @@ RSpec.describe ActiveRecord::Validations::BlobValidator do
     end
   end
 
+  describe 'with Proc/lambda options' do
+    context 'content_type' do
+      context 'arity 0 (no argument)' do
+        before do
+          User.validates :file, blob: { content_type: -> { :image } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq false }
+      end
+
+      context 'arity 1 (receives record)' do
+        before do
+          User.validates :file, blob: { content_type: ->(_record) { :image } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq false }
+      end
+
+      context 'returning an Array' do
+        before do
+          User.validates :file, blob: { content_type: -> { %w[image/jpeg image/png] } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq false }
+      end
+
+      context 'returning a Regexp' do
+        before do
+          User.validates :file, blob: { content_type: -> { /^image/ } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq false }
+      end
+
+      context 'returning a String' do
+        before do
+          User.validates :file, blob: { content_type: -> { 'image/jpeg' } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq false }
+      end
+
+      context 'returning :web_image' do
+        before do
+          User.validates :file, blob: { content_type: -> { :web_image } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: 'sample.tiff', content_type: 'image/tiff')).valid?).to eq false }
+      end
+
+      context 'returning nil (content_type check skipped)' do
+        before do
+          User.validates :file, blob: { content_type: -> { nil } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq true }
+      end
+
+      context 'dynamic based on record state' do
+        before do
+          User.validates :file, blob: {
+            content_type: ->(record) { record.admin? ? %w[text/plain] : %w[image/jpeg] }
+          }
+        end
+
+        def build_user(admin:, **attrs)
+          User.new(**attrs).tap do |user|
+            user.define_singleton_method(:admin?) { admin }
+          end
+        end
+
+        it 'allows text/plain for admin' do
+          user = build_user(admin: true, file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain'))
+          expect(user.valid?).to eq true
+        end
+
+        it 'rejects text/plain for non-admin' do
+          user = build_user(admin: false, file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain'))
+          expect(user.valid?).to eq false
+        end
+
+        it 'allows image/jpeg for non-admin' do
+          user = build_user(admin: false, file: create_file_blob(filename: '600KB.jpg'))
+          expect(user.valid?).to eq true
+        end
+      end
+
+      context 'has_many_attached' do
+        before do
+          User.validates :files, blob: { content_type: ->(_record) { :image } }
+        end
+
+        it { expect(User.new(files: [create_file_blob(filename: '600KB.jpg')]).valid?).to eq true }
+        it { expect(User.new(files: [create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')]).valid?).to eq false }
+      end
+    end
+
+    context 'size_range' do
+      context 'arity 0 (no argument)' do
+        before do
+          User.validates :file, blob: { size_range: -> { 1..1.megabyte } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: '1_4MB.jpg')).valid?).to eq false }
+      end
+
+      context 'arity 1 (receives record)' do
+        before do
+          User.validates :file, blob: { size_range: ->(_record) { 1..1.megabyte } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: '1_4MB.jpg')).valid?).to eq false }
+
+        it 'translates the validation error with the resolved range' do
+          user = User.new(file: create_file_blob(filename: '1_4MB.jpg'))
+          user.validate
+          expect(user.errors.messages[:file][0]).to eq 'File size should be less than 1 MB'
+        end
+      end
+
+      context 'has_many_attached' do
+        before do
+          User.validates :files, blob: { size_range: -> { 1..1.megabyte } }
+        end
+
+        it { expect(User.new(files: [create_file_blob(filename: '600KB.jpg')]).valid?).to eq true }
+        it { expect(User.new(files: [create_file_blob(filename: '1_4MB.jpg')]).valid?).to eq false }
+      end
+    end
+
+    context 'extension' do
+      context 'arity 0 (no argument)' do
+        before do
+          User.validates :file, blob: { extension: -> { %w[jpg png] } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq false }
+      end
+
+      context 'arity 1 (receives record)' do
+        before do
+          User.validates :file, blob: { extension: ->(_record) { %w[jpg png] } }
+        end
+
+        it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+        it { expect(User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')).valid?).to eq false }
+
+        it 'interpolates the resolved extensions into the error' do
+          user = User.new(file: create_file_blob(filename: 'dummy.txt', content_type: 'text/plain'))
+          user.validate
+          error_detail = user.errors.details[:file][0]
+          expect(error_detail[:extension]).to eq('jpg, png')
+        end
+      end
+
+      context 'has_many_attached' do
+        before do
+          User.validates :files, blob: { extension: -> { %w[jpg png] } }
+        end
+
+        it { expect(User.new(files: [create_file_blob(filename: '600KB.jpg')]).valid?).to eq true }
+        it { expect(User.new(files: [create_file_blob(filename: 'dummy.txt', content_type: 'text/plain')]).valid?).to eq false }
+      end
+    end
+
+    context 'combined content_type and extension (AND) via Proc' do
+      before do
+        User.validates :file, blob: {
+          content_type: -> { 'image/jpeg' },
+          extension: ->(_record) { %w[jpg jpeg] }
+        }
+      end
+
+      it { expect(User.new(file: create_file_blob(filename: '600KB.jpg')).valid?).to eq true }
+
+      it 'rejects file when extension does not match even if content_type matches' do
+        user = User.new(file: create_file_blob(filename: 'no_extension'))
+        expect(user.valid?).to eq false
+        expect(user.errors.details[:file].map { |d| d[:error] }).to include(:extension)
+      end
+    end
+  end
+
   describe 'filename parameter in validation errors' do
     context 'content_type validation' do
       before do


### PR DESCRIPTION
Resolves the request in #37: allow blob validator options to be specified as a Proc/lambda so allowed values can be decided per record at validation time.

- All three options (`content_type`, `size_range`, `extension`) now accept a Proc/lambda. Procs are resolved with the same arity convention as Rails' built-in validators (`-> {}` called as-is, `->(record) {}` receives the record); non-Proc values pass through untouched for full backward compatibility.
- Added specs covering arity 0/1, each return type, `nil`, record-dependent dynamic branching, `has_many_attached`, and the content_type+extension AND combination.
- Updated README and SKILL.md / SKILL-ja.md to document the dynamic-option arity convention.